### PR TITLE
Fix overalignment requirement

### DIFF
--- a/bearssl.zig
+++ b/bearssl.zig
@@ -707,7 +707,7 @@ pub fn Stream(comptime SrcInStream: type, comptime SrcOutStream: type) type {
 
         /// low level read from fd to ssl library
         fn sockRead(ctx: ?*c_void, buf: [*c]u8, len: usize) callconv(.C) c_int {
-            var input = @ptrCast(SrcInStream, @alignCast(@alignOf(SrcInStream), ctx.?));
+            var input = @ptrCast(SrcInStream, @alignCast(@alignOf(std.meta.Child(SrcInStream)), ctx.?));
             return if (input.read(buf[0..len])) |num|
                 @intCast(c_int, num)
             else |err|
@@ -716,7 +716,7 @@ pub fn Stream(comptime SrcInStream: type, comptime SrcOutStream: type) type {
 
         /// low level  write from ssl library to fd
         fn sockWrite(ctx: ?*c_void, buf: [*c]const u8, len: usize) callconv(.C) c_int {
-            var output = @ptrCast(SrcOutStream, @alignCast(@alignOf(SrcOutStream), ctx.?));
+            var output = @ptrCast(SrcOutStream, @alignCast(@alignOf(std.meta.Child(SrcOutStream)), ctx.?));
             return if (output.write(buf[0..len])) |num|
                 @intCast(c_int, num)
             else |err|


### PR DESCRIPTION
Existing code actually uses `@alignOf(*Writer)` so it's forcing alignment of 8 bytes, even though the underlying struct has native alignment of 4.