### PR TITLE
Remap zig's read=0 EOF to bearssl -1

### DIFF
--- a/bearssl.zig
+++ b/bearssl.zig
@@ -709,7 +709,7 @@ pub fn Stream(comptime SrcInStream: type, comptime SrcOutStream: type) type {
         fn sockRead(ctx: ?*c_void, buf: [*c]u8, len: usize) callconv(.C) c_int {
             var input = @ptrCast(SrcInStream, @alignCast(@alignOf(std.meta.Child(SrcInStream)), ctx.?));
             return if (input.read(buf[0..len])) |num|
-                @intCast(c_int, num)
+                if (num > 0) @intCast(c_int, num) else -1
             else |err|
                 -1;
         }
@@ -718,7 +718,7 @@ pub fn Stream(comptime SrcInStream: type, comptime SrcOutStream: type) type {
         fn sockWrite(ctx: ?*c_void, buf: [*c]const u8, len: usize) callconv(.C) c_int {
             var output = @ptrCast(SrcOutStream, @alignCast(@alignOf(std.meta.Child(SrcOutStream)), ctx.?));
             return if (output.write(buf[0..len])) |num|
-                @intCast(c_int, num)
+                if (num > 0) @intCast(c_int, num) else -1
             else |err|
                 -1;
         }


### PR DESCRIPTION
Per [bearssl docs](https://bearssl.org/apidoc/bearssl__ssl_8h.html#ab9f7303a713df06e676fc10c6f1de769):

> On error, the callbacks return -1. Reaching end-of-stream is an error. Errors are permanent: the SSL connection is terminated.
> Callbacks SHOULD NOT return 0. This is tolerated, as long as callbacks endeavour to block for some non-negligible amount of time until at least one byte can be sent or received (if a callback returns 0, then the wrapper invokes it again immediately).