### PR TITLE
Miscellaneous Zig Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /zig-cache
+/zig-out
 /.zigmod
 /deps.zig

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -303,6 +303,8 @@ pub const TrustAnchorCollection = struct {
     }
 
     pub fn appendFromPEM(self: *Self, pem_text: []const u8) !void {
+        var arenaAlloc = self.arena.allocator();
+
         var objectBuffer = std.ArrayList(u8).init(self.items.allocator);
         defer objectBuffer.deinit();
 
@@ -345,7 +347,7 @@ pub const TrustAnchorCollection = struct {
                             .data_len = objectBuffer.items.len,
                         };
 
-                        var trust_anchor = try convertToTrustAnchor(&self.arena.allocator, certificate);
+                        var trust_anchor = try convertToTrustAnchor(arenaAlloc, certificate);
 
                         try self.items.append(trust_anchor);
                         // ignore end of
@@ -393,10 +395,10 @@ pub const TrustAnchorCollection = struct {
 
         switch (public_key.key_type) {
             c.BR_KEYTYPE_RSA => {
-                var n = try std.mem.dupe(allocator, u8, public_key.key.rsa.n[0..public_key.key.rsa.nlen]);
+                var n = try allocator.dupe(u8, public_key.key.rsa.n[0..public_key.key.rsa.nlen]);
                 errdefer allocator.free(n);
 
-                var e = try std.mem.dupe(allocator, u8, public_key.key.rsa.e[0..public_key.key.rsa.elen]);
+                var e = try allocator.dupe(u8, public_key.key.rsa.e[0..public_key.key.rsa.elen]);
                 errdefer allocator.free(e);
 
                 ta.pkey = .{
@@ -412,7 +414,7 @@ pub const TrustAnchorCollection = struct {
                 };
             },
             c.BR_KEYTYPE_EC => {
-                var q = try std.mem.dupe(allocator, u8, public_key.key.ec.q[0..public_key.key.ec.qlen]);
+                var q = try allocator.dupe(u8, public_key.key.ec.q[0..public_key.key.ec.qlen]);
                 errdefer allocator.free(q);
 
                 ta.pkey = .{

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -336,7 +336,7 @@ pub const TrustAnchorCollection = struct {
                         try objectBuffer.resize(0);
                         c.br_pem_decoder_setdest(&x509_decoder, appendToBuffer, &objectBuffer);
                     } else {
-                        std.log.warn("ignore object of type '{s}'\n", .{name});
+                        std.log.warn("ignore object of type '{s}'", .{name});
                         c.br_pem_decoder_setdest(&x509_decoder, null, null);
                     }
                 },
@@ -352,11 +352,11 @@ pub const TrustAnchorCollection = struct {
                         try self.items.append(trust_anchor);
                         // ignore end of
                     } else {
-                        std.log.warn("end of ignored object.\n", .{});
+                        std.log.warn("end of ignored object.", .{});
                     }
                 },
                 c.BR_PEM_ERROR => {
-                    std.log.warn("pem error:\n", .{});
+                    std.log.warn("pem error:", .{});
                 },
 
                 else => unreachable, // no other values are specified
@@ -766,10 +766,10 @@ pub fn Stream(comptime SrcReader: type, comptime SrcWriter: type) type {
 
 fn appendToBuffer(dest_ctx: ?*anyopaque, buf: ?*const anyopaque, len: usize) callconv(.C) void {
     var dest_buffer = @ptrCast(*std.ArrayList(u8), @alignCast(@alignOf(std.ArrayList(u8)), dest_ctx));
-    // std.log.warn("read chunk of {} bytes...\n", .{len});
+    // std.log.warn("read chunk of {} bytes...", .{len});
 
     dest_buffer.appendSlice(@ptrCast([*]const u8, buf)[0..len]) catch {
-        std.log.warn("failed to read chunk of {} bytes...\n", .{len});
+        std.log.warn("failed to read chunk of {} bytes...", .{len});
     };
 }
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -711,19 +711,17 @@ pub fn Stream(comptime SrcReader: type, comptime SrcWriter: type) type {
         /// low level read from fd to ssl library
         fn sockRead(ctx: ?*anyopaque, buf: [*c]u8, len: usize) callconv(.C) c_int {
             var input = @ptrCast(SrcReader, @alignCast(@alignOf(std.meta.Child(SrcReader)), ctx.?));
-            return if (input.read(buf[0..len])) |num|
-                if (num > 0) @intCast(c_int, num) else -1
-            else
-                -1;
+
+            var read_result = input.read(buf[0..len]) catch return -1;
+            return if (read_result > 0) @intCast(c_int, read_result) else -1;
         }
 
         /// low level  write from ssl library to fd
         fn sockWrite(ctx: ?*anyopaque, buf: [*c]const u8, len: usize) callconv(.C) c_int {
             var output = @ptrCast(SrcWriter, @alignCast(@alignOf(std.meta.Child(SrcWriter)), ctx.?));
-            return if (output.write(buf[0..len])) |num|
-                if (num > 0) @intCast(c_int, num) else -1
-            else
-                -1;
+
+            var write_result = output.write(buf[0..len]) catch return -1;
+            return if (write_result > 0) @intCast(c_int, write_result) else -1;
         }
 
         const ReadError = error{EndOfStream} || BearError;


### PR DESCRIPTION
My last PR got the project compiling on recent versions of Zig, but it didn't function because I missed some changes that emerged as compilation errors when I started actually referencing declarations/using things.  Cleaned up the following:

- Finished updating to new allocator syntax by fixing the usage of the arena allocators
- Replaced deprecated methods which now produce compiler errors
    - `std.mem.spanZ` -> `std.mem.sliceTo`
    - `std.mem.dupe` -> `std.mem.Allocator.dupe`
    - `ArrayList(T).ensureCapacity` -> `ArrayList(T).ensureUnusedCapacity`
    - `std.debug.warn` -> `std.log.warn`
- Updated reader/writer usage in the `sockRead` and `sockWrite` functions
    - Zig Reader/Writer functions produce errors when operations fail instead of nullable types now

After this, I can communicate with a basic server using a `Client` on Linux.  Windows works as well, with the exception of the `Stream.close()` function producing an error (and this probably is not an issue with the bindings, I didn't look into it).