### PR TITLE
made it a "proper" zig module that provides a static lib that can be linked against projects based on zig v0.13.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,6 +12,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     module.addIncludePath(b.path("BearSSL/inc"));
+    module.addIncludePath(b.path("BearSSL/tools"));
 
     const exe = b.addExecutable(.{
         .name = "zig-bearssl",

--- a/build.zig
+++ b/build.zig
@@ -14,9 +14,7 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = "zig-bearssl",
-        .root_source_file = .{
-            .path = "src/main.zig",
-        },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig
+++ b/build.zig
@@ -19,7 +19,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    bearssl.linkBearSSL(".", exe, target);
+    bearssl.linkBearSSL(".", exe, target, b);
 
     b.installArtifact(exe);
 

--- a/build.zig
+++ b/build.zig
@@ -3,10 +3,14 @@ const std = @import("std");
 pub const bearssl = @import("src/lib.zig");
 
 pub fn build(b: *std.Build) void {
-    _ = b.addModule("bearssl", .{ .source_file = .{ .path = "src/lib.zig" } });
-
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+
+    _ = b.addModule("bearssl", .{
+        .root_source_file = b.path("src/lib.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
 
     const exe = b.addExecutable(.{
         .name = "zig-bearssl",

--- a/build.zig
+++ b/build.zig
@@ -6,11 +6,12 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("bearssl", .{
+    const module = b.addModule("bearssl", .{
         .root_source_file = b.path("src/lib.zig"),
         .target = target,
         .optimize = optimize,
     });
+    module.addIncludePath(b.path("BearSSL/inc"));
 
     const exe = b.addExecutable(.{
         .name = "zig-bearssl",

--- a/build.zig
+++ b/build.zig
@@ -14,23 +14,14 @@ pub fn build(b: *std.Build) void {
     module.addIncludePath(b.path("BearSSL/inc"));
     module.addIncludePath(b.path("BearSSL/tools"));
 
-    const exe = b.addExecutable(.{
+    const lib = b.addStaticLibrary(.{
         .name = "zig-bearssl",
-        .root_source_file = b.path("src/main.zig"),
+        .root_source_file = b.path("src/lib.zig"),
         .target = target,
         .optimize = optimize,
     });
 
-    bearssl.linkBearSSL(".", exe, target, b);
+    bearssl.linkBearSSL(".", lib, target, b);
 
-    b.installArtifact(exe);
-
-    const run_cmd = b.addRunArtifact(exe);
-    run_cmd.step.dependOn(b.getInstallStep());
-    if (b.args) |args| {
-        run_cmd.addArgs(args);
-    }
-
-    const run_step = b.step("run", "Run the app");
-    run_step.dependOn(&run_cmd.step);
+    b.installArtifact(lib);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = "zig-bearssl",
+    .version = "0.1.0",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "LICENSE",
+        "README.md",
+        "BearSSL",
+    },
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -854,12 +854,12 @@ const asn1 = struct {
     }
 };
 const bearssl_sources = [_][]const u8{
-    "/BearSSL/tools/keys.c",
-    "/BearSSL/tools/files.c",
-    "/BearSSL/tools/names.c",
-    "/BearSSL/tools/xmem.c",
-    "/BearSSL/tools/errors.c",
-    "/BearSSL/tools/vector.c",
+    "BearSSL/tools/keys.c",
+    "BearSSL/tools/files.c",
+    "BearSSL/tools/names.c",
+    "BearSSL/tools/xmem.c",
+    "BearSSL/tools/errors.c",
+    "BearSSL/tools/vector.c",
     "BearSSL/src/settings.c",
     "BearSSL/src/aead/ccm.c",
     "BearSSL/src/aead/eax.c",

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -1,14 +1,15 @@
 const std = @import("std");
+const Builder = @import("std").Build;
 
 /// Adds all BearSSL sources to the compile step
 /// Allows simple linking from build scripts.
-pub fn linkBearSSL(path_prefix: []const u8, module: *std.Build.Step.Compile, target: std.Build.ResolvedTarget) void {
+pub fn linkBearSSL(path_prefix: []const u8, module: *std.Build.Step.Compile, target: std.Build.ResolvedTarget, b: *Builder) void {
     module.linkLibC();
 
     const inc_path = module.step.owner.pathJoin(&[_][]const u8{ path_prefix, "BearSSL/inc" });
     const src_path = module.step.owner.pathJoin(&[_][]const u8{ path_prefix, "BearSSL/src" });
-    module.addIncludePath(.{ .path = inc_path });
-    module.addIncludePath(.{ .path = src_path });
+    module.addIncludePath(b.path(inc_path));
+    module.addIncludePath(b.path(src_path));
 
     const paths = addPrefixToPaths(module.step.owner, path_prefix, &bearssl_sources);
     defer {

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 /// Adds all BearSSL sources to the compile step
 /// Allows simple linking from build scripts.
-pub fn linkBearSSL(path_prefix: []const u8, module: *std.Build.Step.Compile, target: std.zig.CrossTarget) void {
+pub fn linkBearSSL(path_prefix: []const u8, module: *std.Build.Step.Compile, target: std.Build.ResolvedTarget) void {
     module.linkLibC();
 
     const inc_path = module.step.owner.pathJoin(&[_][]const u8{ path_prefix, "BearSSL/inc" });

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -29,7 +29,7 @@ pub fn linkBearSSL(path_prefix: []const u8, module: *std.Build.Step.Compile, tar
         });
     }
 
-    if (target.isWindows()) {
+    if (target.result.os.tag == std.Target.Os.Tag.windows) {
         module.linkSystemLibrary("advapi32");
     }
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -19,7 +19,7 @@ pub fn linkBearSSL(path_prefix: []const u8, module: *std.Build.Step.Compile, tar
         module.step.owner.allocator.free(paths);
     }
 
-    inline for (paths) |srcfile| {
+    for (paths) |srcfile| {
         module.addCSourceFile(.{
             .file = b.path(srcfile),
             .flags = &[_][]const u8{

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -19,13 +19,15 @@ pub fn linkBearSSL(path_prefix: []const u8, module: *std.Build.Step.Compile, tar
         module.step.owner.allocator.free(paths);
     }
 
-    module.addCSourceFiles(
-        paths,
-        &[_][]const u8{
-            "-Wall",
-            "-DBR_LE_UNALIGNED=0", // this prevent BearSSL from using undefined behaviour when doing potential unaligned access
-        },
-    );
+    inline for (paths) |srcfile| {
+        module.addCSourceFile(.{
+            .file = b.path(srcfile),
+            .flags = &[_][]const u8{
+                "-Wall",
+                "-DBR_LE_UNALIGNED=0", // this prevent BearSSL from using undefined behaviour when doing potential unaligned access
+            },
+        });
+    }
 
     if (target.isWindows()) {
         module.linkSystemLibrary("advapi32");

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -46,6 +46,7 @@ fn addPrefixToPaths(b: *std.Build, prefix: []const u8, paths: []const []const u8
 // Export C for advanced interfacing
 pub const c = @cImport({
     @cInclude("bearssl.h");
+    @cInclude("brssl.h");
 });
 
 pub const BearError = error{
@@ -107,8 +108,10 @@ pub const BearError = error{
     X509_FORBIDDEN_KEY_USAGE,
     X509_WEAK_PUBLIC_KEY,
     X509_NOT_TRUSTED,
+    UNKNOWN_ERROR_552,
+    UNKNOWN_ERROR_582,
 };
-fn convertError(err: c_int) BearError {
+pub fn convertError(err: c_int) BearError {
     return switch (err) {
         c.BR_ERR_BAD_PARAM => error.BAD_PARAM,
         c.BR_ERR_BAD_STATE => error.BAD_STATE,

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -854,6 +854,12 @@ const asn1 = struct {
     }
 };
 const bearssl_sources = [_][]const u8{
+    "/BearSSL/tools/keys.c",
+    "/BearSSL/tools/files.c",
+    "/BearSSL/tools/names.c",
+    "/BearSSL/tools/xmem.c",
+    "/BearSSL/tools/errors.c",
+    "/BearSSL/tools/vector.c",
     "BearSSL/src/settings.c",
     "BearSSL/src/aead/ccm.c",
     "BearSSL/src/aead/eax.c",


### PR DESCRIPTION
i apologize if you believe i bastardized parts of this. but i think that having a static lib instead of an exe in a module (with c sources) makes more sense.

i use it like this:

1. add zig-bearssl az a dep to my project:
```sh
zig fetch --save 'git+https://github.com/stef/zig-bearssl/#HEAD'
```
2. tell build.zig about the fine details:
```zig
const bearssl_package = b.dependency("zig-bearssl", .{
    .target = target,
    .optimize = optimize,
});
const bearssl_module = bearssl_package.module("bearssl");

// [...snip...]

exe.root_module.addImport("bearssl", bearssl_module);
exe.linkLibrary(bearssl_package.artifact("zig-bearssl"));
```
3. use the fruits of our labour in our code:
```zig
const ssl = @import("bearssl");
// load an ssl private key
const sk: *ssl.c.private_key = ssl.c.read_private_key(@ptrCast(cfg.ssl_key));
// ... do other stuff
```