### PR TITLE
[fix] UBSan triggers on bad function sig in ssl/ssl_engine.c:318

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -32,6 +32,15 @@ pub fn build(b: *std.Build) void {
         },
     });
 
+    // src/ssl/ssl_engine.c:318 is special ReleaseSafe triggers a UBSan exception
+    // consulted with upstream proposed this solution.
+    module.addCSourceFile(.{
+        .file = bearssl_dep.path("src/ssl/ssl_engine.c"),
+        .flags = &[_][]const u8{
+            "-Wall",
+            "-fno-sanitize=function",
+            "-DBR_LE_UNALIGNED=0"} });
+
     if (target.result.os.tag == .windows) {
         module.linkSystemLibrary("advapi32", .{ .needed = true });
     }
@@ -271,7 +280,7 @@ const bearssl_sources = [_][]const u8{
     "src/ssl/ssl_client.c",
     "src/ssl/ssl_client_default_rsapub.c",
     "src/ssl/ssl_client_full.c",
-    "src/ssl/ssl_engine.c",
+    //"src/ssl/ssl_engine.c",
     "src/ssl/ssl_engine_default_aescbc.c",
     "src/ssl/ssl_engine_default_aesccm.c",
     "src/ssl/ssl_engine_default_aesgcm.c",

--- a/build.zig
+++ b/build.zig
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build) void {
         .files = &bearssl_sources,
         .flags = &.{
             "-Wall",
-            //"-fno-sanitize=function", // bearssl depends on this
+            "-fno-sanitize=function", // bearssl depends on this
             "-DBR_LE_UNALIGNED=0", // this prevent BearSSL from using undefined behaviour when doing potential unaligned access
         },
     });

--- a/build.zig
+++ b/build.zig
@@ -28,18 +28,10 @@ pub fn build(b: *std.Build) void {
         .files = &bearssl_sources,
         .flags = &.{
             "-Wall",
+            "-fno-sanitize=function", // bearssl depends on this
             "-DBR_LE_UNALIGNED=0", // this prevent BearSSL from using undefined behaviour when doing potential unaligned access
         },
     });
-
-    // src/ssl/ssl_engine.c:318 is special ReleaseSafe triggers a UBSan exception
-    // consulted with upstream proposed this solution.
-    module.addCSourceFile(.{
-        .file = bearssl_dep.path("src/ssl/ssl_engine.c"),
-        .flags = &[_][]const u8{
-            "-Wall",
-            "-fno-sanitize=function",
-            "-DBR_LE_UNALIGNED=0"} });
 
     if (target.result.os.tag == .windows) {
         module.linkSystemLibrary("advapi32", .{ .needed = true });

--- a/build.zig
+++ b/build.zig
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build) void {
         .files = &bearssl_sources,
         .flags = &.{
             "-Wall",
-            "-fno-sanitize=function", // bearssl depends on this
+            //"-fno-sanitize=function", // bearssl depends on this
             "-DBR_LE_UNALIGNED=0", // this prevent BearSSL from using undefined behaviour when doing potential unaligned access
         },
     });
@@ -272,7 +272,7 @@ const bearssl_sources = [_][]const u8{
     "src/ssl/ssl_client.c",
     "src/ssl/ssl_client_default_rsapub.c",
     "src/ssl/ssl_client_full.c",
-    //"src/ssl/ssl_engine.c",
+    "src/ssl/ssl_engine.c",
     "src/ssl/ssl_engine_default_aescbc.c",
     "src/ssl/ssl_engine_default_aesccm.c",
     "src/ssl/ssl_engine_default_aesgcm.c",


### PR DESCRIPTION
if compiled with -Doptimize=ReleaseSafe UBSan triggers an exception, after consulting with upstream this is the proposed solution.